### PR TITLE
Deprecated Import

### DIFF
--- a/Guided_Evolutionary_Strategies_Demo_Jax.ipynb
+++ b/Guided_Evolutionary_Strategies_Demo_Jax.ipynb
@@ -58,7 +58,7 @@
     "\n",
     "import jax\n",
     "import jax.numpy as jnp\n",
-    "from jax.experimental import optimizers\n",
+    "from jax.example_libraries import optimizers\n",
     "\n",
     "print(f'Jax version: {jax.__version__}')"
    ]


### PR DESCRIPTION
Deprecated import: Use jax.example_libraries.optimizers instead of jax.experimental.optimizers.

See: https://stackoverflow.com/questions/75238223/jax-experimental-importing-error-python-3-9